### PR TITLE
doc: replace ndjson[dot]org with ndjson spec

### DIFF
--- a/docs/ingest-api.mdx
+++ b/docs/ingest-api.mdx
@@ -159,7 +159,7 @@ public class Example {
   </TabItem>
 </Tabs>
 
-You can push Newline Delimited JSON (http://ndjson.org/) to the endpoint. Make sure you set the HTTP Header as one of these:
+You can push Newline Delimited JSON (https://github.com/ndjson/ndjson-spec/) to the endpoint. Make sure you set the HTTP Header as one of these:
 
 - `application/x-ndjson`
 - `application/vnd.timeplus+json;format=streaming`

--- a/i18n/zh/docusaurus-plugin-content-docs/current/ingest-api.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/ingest-api.mdx
@@ -157,7 +157,7 @@ public class Example {
 </TabItem>
 </Tabs>
 
-您可以将换行符分隔的 JSON (http://ndjson.org/) 推送到终端节点。 确保将 HTTP 标头设置为以下内容之一：
+您可以将换行符分隔的 JSON (https://github.com/ndjson/ndjson-spec/) 推送到终端节点。 确保将 HTTP 标头设置为以下内容之一：
 
 -
 - `application/vnd.timeplus+json; format=streaming`


### PR DESCRIPTION
the `ndjson[dot]org` expired, and point to incorrect website with malware. more in ndjson/ndjson.github.io#24

https://github.com/timeplus-io/proton/issues/908