### PR TITLE
`console.log()` is already available in Proton 1.6.5

### DIFF
--- a/docs/sql-create-function.md
+++ b/docs/sql-create-function.md
@@ -59,7 +59,7 @@ Note:
 You can also add `EXECUTION_TIMEOUT <num>` to the end of the `CREATE FUNCTION` to customize the timeout for calling remote endpoints. By default the timeout is 10000 milliseconds (i.e. 10 seconds).
 
 :::info
-In Timeplus Enterprise, you can add debug information via `console.log(..)` in the JavaScript UDF. The logs will be available in the server log files.
+You can add debug information via `console.log(..)` in the JavaScript UDF. The logs will be available in the server log files.
 :::
 
 ### UDAF {#js-udaf}


### PR DESCRIPTION
https://github.com/timeplus-io/proton/pull/870

Starting from Proton 1.6.5, we can use `console.log` in JS UDF. 
It has been two months since then, I don't want to focus on versioning here.