### PR TITLE
Update default limit for dedup function to 10000

### DIFF
--- a/docs/functions_for_streaming.md
+++ b/docs/functions_for_streaming.md
@@ -73,7 +73,7 @@ For example, if the car keeps sending data when it's moving and stops sending da
 
 Apply the deduplication at the given data stream with the specified column(s). Rows with same column value will only show once (only the first row is selected and others are omitted.) `liveInSecond` specifies how long the keys will be kept in the memory/state. By default forever. But if you only want to avoid duplicating within a certain time period, say 2 minutes, you can set `120s`, e.g. `dedup(subquery,myId,120s)`
 
-The last parameter `limit` is optional which is `100000` by default. It limits the max unique keys maintained in the query engine. If the limit reaches, the system will recycle the earliest keys to maintain this limit.
+The last parameter `limit` is optional which is `10000` by default. It limits the max unique keys maintained in the query engine. If the limit reaches, the system will recycle the earliest keys to maintain this limit.
 
 You can cascade this table function like `tumble(dedup(table(....` and so far the wrapping order must in this sequence : tumble/hop/session -> dedup -> table.
 


### PR DESCRIPTION
### proton:

https://github.com/timeplus-io/proton/blob/b569d87ef64db5718911e37a025a133603aaf08f/src/Processors/Transforms/Streaming/DedupTransform.cpp#L187-L194

### timeplusd: 
```
timeplusd client version 3.1.3-rc.0.
Connecting to localhost:8463 as user default.
Connected to timeplusd server version 3.1.3 revision 54473.

timeplusd :) CREATE STREAM IF NOT EXISTS src_dedup_bug (id int, value string);
             CREATE STREAM IF NOT EXISTS tgt_dedup_bug (id int, value string);


timeplusd :) 
             
             
             CREATE MATERIALIZED VIEW mv_dedup_bug INTO tgt_dedup_bug
             AS SELECT id, value
             FROM dedup(src_dedup_bug, id, 3600s);


timeplusd :) INSERT INTO src_dedup_bug (id, value)
             SELECT number, 'batch4' FROM numbers(15000);

0 rows in set. Elapsed: 0.002 sec. Processed 15.00 thousand rows, 120.00 KB (7.76 million rows/s., 62.06 MB/s.)

timeplusd :) 
             SELECT count() as total_rows FROM table(tgt_dedup_bug);

SELECT
  count() AS total_rows
FROM
  table(tgt_dedup_bug)

Query id: ee418e13-966d-4636-afaa-353f5ac334ee

┌─total_rows─┐
│      15000 │
└────────────┘

1 row in set. Elapsed: 0.014 sec. 

timeplusd :) 
             INSERT INTO src_dedup_bug (id, value)
             SELECT number, 'batch3' FROM numbers(15000);

0 rows in set. Elapsed: 0.002 sec. Processed 15.00 thousand rows, 120.00 KB (7.75 million rows/s., 62.00 MB/s.)

timeplusd :) 
             SELECT count() as total_rows FROM table(tgt_dedup_bug);

SELECT
  count() AS total_rows
FROM
  table(tgt_dedup_bug)

Query id: f4544e9e-72f8-42ab-86d0-684787ccc57a

┌─total_rows─┐
│      20000 │
└────────────┘

1 row in set. Elapsed: 0.002 sec. 

timeplusd :) 


```