### PR TITLE
Add Timeplus Enterprise 3.3 to sidebar and release notes

### DIFF
--- a/docs/enterprise-v3.3.md
+++ b/docs/enterprise-v3.3.md
@@ -4,6 +4,13 @@
 
 Key highlights of the Timeplus 3.3 release include:
 
+1. New **backup and recovery** capabilities: a stream tool for stream data recovery and backup/restore, sequence-aware backup and recovery controls, plus more resilient recovery paths with incremental commit replay and self-healing from torn WAL tails.
+2. Smarter **cluster workload balancing**: stream-shard leader rebalancing and a reliable workload rebalancer for materialized views, with new `SYSTEM TRANSFER SCHED MATERIALIZED VIEW` / `SYSTEM REBALANCE SCHED MATERIALIZED VIEWS` commands and configurable scheduling policies.
+3. Major **Python UDF** upgrades: embedded CPython migrated to **3.14 free-threaded** with improved observability, UDF init hooks via SETTINGS, and automatic package reconciliation from S3-hosted requirements.txt.
+4. Faster and leaner **startup and recovery**: lazy-loaded primary key index to bound startup memory, memory-pressure interventions to prevent materialized-view reboot recovery storms, and containment of single-table startup failures.
+5. Streaming SQL enhancements: **streaming LEFT ANTI JOIN**, `SHUFFLE BY` propagation through CTE/subquery boundaries, shard pruning for IN-subqueries, and a new offsets-only checkpoint mode.
+6. Broad stability and correctness hardening across **Raft replication, checkpoints, mutable streams, Kafka sources, and memory accounting**.
+
 
 ## Supported OS {#os}
 |Deployment Type| OS |

--- a/docs/release-downloads.md
+++ b/docs/release-downloads.md
@@ -3,7 +3,7 @@
 ## 3.x {#3_x}
 
 ### v3.3.1 {#3_3_1}
-Released on 08-01-2026 ([Change logs](/enterprise-v3.2#3_3_1)).
+Released on 08-01-2026 ([Change logs](/enterprise-v3.3#3_3_1)).
 
 * Bare metal installation: [Linux x86_64](https://d.timeplus.com/timeplus-enterprise-v3.3.1-linux-amd64.tar.gz) | [Linux ARM64](https://d.timeplus.com/timeplus-enterprise-v3.3.1-linux-arm64.tar.gz) | [macOS x86_64](https://d.timeplus.com/timeplus-enterprise-v3.3.1-darwin-amd64.tar.gz) | [macOS ARM64](https://d.timeplus.com/timeplus-enterprise-v3.3.1-darwin-arm64.tar.gz)
 * All-in-one Docker image (not recommended for production): `docker run -p 8000:8000 docker.timeplus.com/timeplus/timeplus-enterprise:3.3.1`

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,7 @@
 # Release
 
 Release by version:
+- [Timeplus Enterprise 3.3](/enterprise-v3.3)
 - [Timeplus Enterprise 3.2](/enterprise-v3.2)
 - [Timeplus Enterprise 3.1](/enterprise-v3.1)
 - [Timeplus Enterprise 3.0](/enterprise-v3.0)

--- a/sidebars.js
+++ b/sidebars.js
@@ -990,6 +990,7 @@ const sidebars = {
         id: "release-notes",
       },
       items: [
+        "enterprise-v3.3",
         "enterprise-v3.2",
         "enterprise-v3.1",
         "enterprise-v3.0",


### PR DESCRIPTION
## Summary

- Add `enterprise-v3.3` to the RELEASES section in `sidebars.js`, so Timeplus Enterprise 3.3 shows up in the sidebar (same approach as the 3.2 update).
- Add the 3.3 link to the version list in `release-notes.md`.
- Fill in the Key Highlights section of `enterprise-v3.3.md`, summarized from the 3.3.1 changelog — please review the wording and selection.
- Fix a broken anchor found during build: the v3.3.1 change-log link in `release-downloads.md` pointed to `/enterprise-v3.2#3_3_1`, now `/enterprise-v3.3#3_3_1`.

Verified with `yarn build`: no broken links or anchors.